### PR TITLE
- Domain length is a int instead of string

### DIFF
--- a/server.py
+++ b/server.py
@@ -50,7 +50,7 @@ class SocksProxy(StreamRequestHandler):
         if address_type == 1:  # IPv4
             address = socket.inet_ntoa(self.connection.recv(4))
         elif address_type == 3:  # Domain name
-            domain_length = ord(self.connection.recv(1)[0])
+            domain_length = self.connection.recv(1)[0]
             address = self.connection.recv(domain_length)
             address = socket.gethostbyname(address)
         port = struct.unpack('!H', self.connection.recv(2))[0]


### PR DESCRIPTION
- Firefox with Proxy DNS and Chrome would fail, so just a little fix